### PR TITLE
Fix Clipped Chart Labels on Export

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cli calculator",
     "typescript calculator"
   ],
-  "author": "ahmed ali ansari",
+  "author": "ahmed ali ansari", Hd2qka4GyA
   "license": "ISC",
   "dependencies": {
     "chalk": "^5.1.2",


### PR DESCRIPTION
Resolved issues causing labels to be clipped in exported charts.